### PR TITLE
Fix heapify error

### DIFF
--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/heap.js
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/heap.js
@@ -88,7 +88,7 @@ export class MinHeap {
       this.heap = array;
     }
     const maxIndex = Math.floor(this.size() / 2) - 1;
-    for (let i = 0; i <= maxIndex; i++) {
+    for (let i = maxIndex; i >= 0; i--) {
       this.siftDown(i);
     }
     return this.heap;


### PR DESCRIPTION
Heapify function error, in MinHeap, heapify([2, 5, 4, 1, 3, 6]) result is [ 2, 1, 4, 5, 3, 6 ], should be [1, 2, 4, 5, 3, 6]

test case
```js
  it('heapify test', () => {
    let arr = [2, 5, 4, 1, 3, 6]
    expect(heap.heapify(arr)).to.deep.equal([1, 2, 4, 5, 3, 6])
  })
```