### PR TITLE
fix: fix hash-table-linear-probing file get method

### DIFF
--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/hash-table-linear-probing.js
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/hash-table-linear-probing.js
@@ -47,7 +47,7 @@ export default class HashTableLinearProbing {
         index++;
       }
       if (this.table[index] != null && this.table[index].key === key) {
-        return this.table[position].value;
+        return this.table[index].value;
       }
     }
     return undefined;


### PR DESCRIPTION
Hello!

test demo

```js
const hash = new HashTableLinearProbing();
hash.put('Ygritte', 'ygritte@email.com'); // hashCode: 4
hash.put('Jonathan', 'jonathan@email.com'); // hashCode: 5
hash.put('Jamie', 'jamie@email.com'); // hashCode: 5

console.log(hash.get('Jamie')); // jonathan@email.com
```
this log should be 'jamie@email.com', but get 'jonathan@email.com'

The Error log reason is this line `return this.table[position].value`  after  `while loop`

not `return this.table[position].value`,

**the correct is** `return this.table[index].value`


