### PR TITLE
fix: fix avl-tree removeNode func problem

### DIFF
--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/avl-tree.js
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/avl-tree.js
@@ -138,8 +138,16 @@ export default class AVLTree extends BinarySearchTree {
         return this.rotationLL(node);
       }
       // Left right case
+      // eg:
+      //     e                              e                               e
+      //    / \      rotationRR(node.left) / \        roationLL(node)      / \ 
+      //   c  ...   -> rotationRR(a) ->   c   ...   -> roationLL(c) ->    b   ...
+      //  /                              /                               / \       
+      // a                              b                               a   c
+      //  \                            / 
+      //   b                          a
       if (this.getBalanceFactor(node.left) === BalanceFactor.SLIGHTLY_UNBALANCED_RIGHT) {
-        return this.rotationLR(node.left);
+        return this.rotationLR(node);
       }
     }
     if (balanceFactor === BalanceFactor.UNBALANCED_RIGHT) {
@@ -151,8 +159,16 @@ export default class AVLTree extends BinarySearchTree {
         return this.rotationRR(node);
       }
       // Right left case
+      // eg:
+      //     a                              a                           a
+      //    / \     rotationLL(node.right) / \       roationRR(node)   / \ 
+      // ...   b    -> rotationLL(d) ->  ...  b   -> roationRR(b) -> ...  c
+      //        \                              \                         / \       
+      //        d                               c                       b   d
+      //       /                                 \
+      //      c                                   d
       if (this.getBalanceFactor(node.right) === BalanceFactor.SLIGHTLY_UNBALANCED_LEFT) {
-        return this.rotationRL(node.right);
+        return this.rotationRL(node);
       }
     }
     return node;

--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/ts/data-structures/avl-tree.ts
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/ts/data-structures/avl-tree.ts
@@ -177,8 +177,16 @@ export default class AVLTree<T> extends BinarySearchTree<T> {
         return this.rotationLL(node);
       }
       // Left right case
+       // eg:
+      //     e                              e                               e
+      //    / \      rotationRR(node.left) / \        roationLL(node)      / \ 
+      //   c  ...   -> rotationRR(a) ->   c   ...   -> roationLL(c) ->    b   ...
+      //  /                              /                               / \       
+      // a                              b                               a   c
+      //  \                            / 
+      //   b   
       if (this.getBalanceFactor(node.left) === BalanceFactor.SLIGHTLY_UNBALANCED_RIGHT) {
-        return this.rotationLR(node.left);
+        return this.rotationLR(node);
       }
     }
 
@@ -191,8 +199,16 @@ export default class AVLTree<T> extends BinarySearchTree<T> {
         return this.rotationRR(node);
       }
       // Right left case
+      // eg:
+      //     a                              a                           a
+      //    / \     rotationLL(node.right) / \       roationRR(node)   / \ 
+      // ...   b    -> rotationLL(d) ->  ...  b   -> roationRR(b) -> ...  c
+      //        \                              \                         / \       
+      //        d                               c                       b   d
+      //       /                                 \
+      //      c                                   d
       if (this.getBalanceFactor(node.right) === BalanceFactor.SLIGHTLY_UNBALANCED_LEFT) {
-        return this.rotationRL(node.right);
+        return this.rotationRL(node);
       }
     }
 


### PR DESCRIPTION
Fixes #14 
AVL-tree removeNode function
```js
     // Left right case 
     if (this.getBalanceFactor(node.left) === BalanceFactor.SLIGHTLY_UNBALANCED_RIGHT) { 
       return this.rotationLR(node.left); 
     } 
```
I think this code is not correct;
eg:
```
                      10
                 ↙          ↘  
            6                     。。。
        ↙       ↘         
      3             8       
         ↘       
             4
```
1. remove node `key = 8`;
2. node `key=6` is not balanced;
3. condition accord with `balanceFactor === BalanceFactor.UNBALANCED_RIGHT `;
4. run `return this.rotationLR(node.left);`, it's will be throw error;

##### in fact, this condition need `return this.rotationLR(node)`;

also, Right-left-case has same error
```js
 // Right left case
  if (this.getBalanceFactor(node.right) === BalanceFactor.SLIGHTLY_UNBALANCED_LEFT) {
       // need change code
        return this.rotationRL(node.right);
        ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
        return this.rotationRL(node);
   }
```