### PR TITLE
fixing wrong reading cause out of bounds

### DIFF
--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/circular-linked-list.js
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/js/data-structures/circular-linked-list.js
@@ -1,6 +1,6 @@
-import { defaultEquals } from '../util';
-import LinkedList from './linked-list';
-import { Node } from './models/linked-list-models';
+import { defaultEquals } from "../util";
+import LinkedList from "./linked-list";
+import { Node } from "./models/linked-list-models";
 
 export default class CircularLinkedList extends LinkedList {
   constructor(equalsFn = defaultEquals) {
@@ -30,7 +30,7 @@ export default class CircularLinkedList extends LinkedList {
           node.next = this.head;
         } else {
           node.next = current;
-          current = this.getElementAt(this.size());
+          current = this.getElementAt(this.size() - 1);
           // update last element
           this.head = node;
           current.next = this.head;

--- a/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/ts/data-structures/circular-linked-list.ts
+++ b/LearningJavaScriptDataStructuresandAlgorithmsThirdEdition_Code/src/ts/data-structures/circular-linked-list.ts
@@ -1,6 +1,6 @@
-import { defaultEquals, IEqualsFunction } from '../util';
-import LinkedList from './linked-list';
-import { Node } from './models/linked-list-models';
+import { defaultEquals, IEqualsFunction } from "../util";
+import LinkedList from "./linked-list";
+import { Node } from "./models/linked-list-models";
 
 export default class CircularLinkedList<T> extends LinkedList<T> {
   constructor(protected equalsFn: IEqualsFunction<T> = defaultEquals) {
@@ -36,7 +36,7 @@ export default class CircularLinkedList<T> extends LinkedList<T> {
           node.next = this.head;
         } else {
           node.next = current;
-          current = this.getElementAt(this.size());
+          current = this.getElementAt(this.size() - 1);
           // update last element
           this.head = node;
           current.next = this.head;


### PR DESCRIPTION
```ts
this.getElementAt(this.size());
```

this line is reading out of bounds, will get return of `undefined` . Instead of getting the last element in the linked list as we expected

I also checked the `insert` implementation of other linked lists in the project , and didn't find this error. I think Its may be a typo or sth.